### PR TITLE
Removed devicePixelRatio from resize computed size to fix resize issue on Mac with trackpad

### DIFF
--- a/.changeset/happy-dodos-matter.md
+++ b/.changeset/happy-dodos-matter.md
@@ -1,0 +1,5 @@
+---
+"@codeimage/app": patch
+---
+
+fix: fix resize issue on Mac with different devicePixelRatio

--- a/apps/codeimage/src/core/hooks/resizable.ts
+++ b/apps/codeimage/src/core/hooks/resizable.ts
@@ -94,10 +94,9 @@ export function createHorizontalResize(
     const max = maxWidth();
     const isLTR = state.startX > middle;
 
-    const computedWidth =
-      (isLTR
-        ? state.startWidth + x - state.startX
-        : state.startWidth - x + state.startX) * window.devicePixelRatio;
+    const computedWidth = isLTR
+      ? state.startWidth + x - state.startX
+      : state.startWidth - x + state.startX;
 
     setState({width: clamp(computedWidth, min, max)});
   };


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/riccardoperra/codeimage/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Multiplication of resizing size if devicePixelRatio is greater than 1

Issue Number: N/A (discussed privately)

## What is the new behavior?

-

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

## Other information

_
