### PR TITLE
fix(ui): :bug: fix exported image tab styles for only single tab

### DIFF
--- a/apps/codeimage/src/components/Terminal/Tabs/TerminalWindowTabList.tsx
+++ b/apps/codeimage/src/components/Terminal/Tabs/TerminalWindowTabList.tsx
@@ -57,6 +57,7 @@ export function TerminalWindowTabList(
     <div
       class={styles.wrapper({accent: props.accent})}
       data-accent-visible={props.accent}
+      data-tabs={editors.length}
     >
       <div class={styles.tabListWrapper} ref={wrapperRef}>
         {/* @ts-expect-error: TODO: Should update library types */}

--- a/packages/dom-export/src/lib/cloneSafe.ts
+++ b/packages/dom-export/src/lib/cloneSafe.ts
@@ -13,6 +13,15 @@ export async function cloneNodeSafe(node: HTMLElement) {
       .querySelectorAll('[data-export-exclude=true]')
       .forEach(cb => cb.remove());
 
+    const firstTab = clonedNode
+      .querySelector('[data-tabs="1"]')
+      ?.querySelector('[class*="Tab_undefined_compound"]');
+    firstTab?.classList.forEach(c => {
+      if (c.indexOf('Tab_undefined_compound') == 0) {
+        firstTab.classList.remove(c);
+      }
+    });
+
     return clonedNode;
   });
 }


### PR DESCRIPTION
Strips out accent css classes of WindowTab and TerminalWindowTabList after cloning

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/riccardoperra/codeimage/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Exported image was having active tab styles even when single tab was present

Issue Number: 278

## What is the new behavior?

This will export code image without active tab styles if there is only a single tab present

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
Here is screenshot of image having only single tab 
![Single Tab](https://user-images.githubusercontent.com/34616118/175906257-1bf66dc9-12c1-4c2d-a329-1e966df503c4.jpg)

Here is one with multiple tabs
![Multiple Tabs](https://user-images.githubusercontent.com/34616118/175906283-bba7d877-ba71-4fb4-bc6f-41221d01e6a6.jpg)

