### PR TITLE
fix(ui): fix generated types with rollup

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -80,7 +80,7 @@ jobs:
 
   typecheck-packages:
     if: ${{ needs.install.outputs.libs-change == 'true' }}
-    name: Typecheck packages
+    name: Type-checking
     needs: [ install ]
     runs-on: ubuntu-latest
     steps:
@@ -96,32 +96,19 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
+      - name: Prisma migrate
+        run: |
+          cd apps/api
+          pnpm exec prisma generate
+          pnpm --filter=@codeimage/prisma-models build
+
       - name: Typecheck packages
         run: |
           pnpm --filter='./packages/**' --recursive typecheck:ci
 
-
-  typecheck-app:
-    if: (${{ needs.install.outputs.app-change == 'true' }} || ${{ needs.install.outputs.libs-change == 'true' }})
-    name: Typecheck app
-    needs: [ typecheck-packages ]
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v2
-      - uses: pnpm/action-setup@v2.2.2
-        with:
-          version: 7
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
-        with:
-          node-version: ${{ matrix.node-version }}
-          cache: 'pnpm'
-      - name: Install dependencies
-        run: pnpm install
-
-      - name: Typecheck packages
+      - name: Typecheck app
         run: |
+          pnpm --filter='@codeimage/api' typecheck:ci
           pnpm --filter='@codeimage/app' typecheck
 
 
@@ -296,7 +283,6 @@ jobs:
       build-packages,
       build-api,
       typecheck-packages,
-      typecheck-app,
       be-test
     ]
     runs-on: ubuntu-latest

--- a/apps/api/api-types/index.d.ts
+++ b/apps/api/api-types/index.d.ts
@@ -4,4 +4,4 @@ export type {
   UpdateProjectApi,
   UpdateProjectNameApi,
   GetProjectByIdApi,
-} from '../src/schemas';
+} from '../dist/schemas';

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -15,6 +15,7 @@
     "test": "npm run build:ts && tsc -p test/tsconfig.json && dotenv -e .env.test -- tap --ts --reporter=specy './test/**/*.test.ts' --before=test/before-test.ts",
     "start": "npm run build:ts && fastify start -l info dist/app.js",
     "typecheck": "tsc --noEmit --skipLibCheck --project tsconfig.json",
+    "typecheck:ci": "tsc --skipLibCheck --project tsconfig.dts.json",
     "build:ts": "tsc",
     "watch:ts": "tsc -w",
     "prisma:generate": "prisma generate dev && pnpm --filter=@codeimage/prisma-models build",

--- a/apps/api/tsconfig.dts.json
+++ b/apps/api/tsconfig.dts.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "declarationMap": false,
+    "outDir": "./dist"
+  },
+}

--- a/apps/codeimage/src/components/PropertyEditor/EditorSidebar.tsx
+++ b/apps/codeimage/src/components/PropertyEditor/EditorSidebar.tsx
@@ -1,5 +1,3 @@
-import {CodeImageLogo} from '../Icons/CodeImageLogo';
-import * as styles from '../Scaffold/Sidebar/Sidebar.css';
 import {EditorForm} from './EditorForm';
 import {EditorStyleForm} from './EditorStyleForm';
 import {FrameStyleForm} from './FrameStyleForm';

--- a/apps/codeimage/src/components/PropertyEditor/WindowStyleForm.tsx
+++ b/apps/codeimage/src/components/PropertyEditor/WindowStyleForm.tsx
@@ -1,5 +1,4 @@
 import {useI18n} from '@codeimage/locale';
-import {setShowWatermark} from '@codeimage/store/terminal';
 import {getTerminalState} from '@codeimage/store/editor/terminal';
 import {SegmentedField, Select} from '@codeimage/ui';
 import {shadowsLabel, TERMINAL_SHADOWS} from '@core/configuration/shadow';

--- a/apps/codeimage/src/components/Terminal/TerminalHost.tsx
+++ b/apps/codeimage/src/components/Terminal/TerminalHost.tsx
@@ -1,5 +1,5 @@
 import {LanguageIconDefinition} from '@codeimage/config';
-import {TerminalState} from '@codeimage/store/terminal/model';
+import {TerminalState} from '@codeimage/store/editor/model';
 import {FadeInOutTransition, themeVars} from '@codeimage/ui';
 import {assignInlineVars} from '@vanilla-extract/dynamic';
 import clsx from 'clsx';

--- a/apps/codeimage/src/components/Terminal/WindowsTerminal/WindowsTerminal.css.ts
+++ b/apps/codeimage/src/components/Terminal/WindowsTerminal/WindowsTerminal.css.ts
@@ -1,6 +1,5 @@
-import {createTheme, style} from '@vanilla-extract/css';
 import {themeVars} from '@codeimage/ui';
-import {header} from '../terminal.css';
+import {createTheme, style} from '@vanilla-extract/css';
 
 export const [theme, vars] = createTheme({
   iconFill: themeVars.backgroundColor.black,

--- a/apps/codeimage/src/components/Toolbar/LanguageSelectorButton.tsx
+++ b/apps/codeimage/src/components/Toolbar/LanguageSelectorButton.tsx
@@ -22,7 +22,7 @@ export const LanguageSelectorButton = (props: LanguageSelectorButtonProps) => {
     <>
       <DropdownMenuV2
         selectionMode={'single'}
-        onAction={item => onUpdateLanguage(item)}
+        onAction={item => onUpdateLanguage(item as string)}
         selectedKeys={[props.currentLocale]}
         menuButton={
           <MenuButton

--- a/apps/codeimage/src/components/Toolbar/ShareButton.tsx
+++ b/apps/codeimage/src/components/Toolbar/ShareButton.tsx
@@ -10,6 +10,7 @@ interface ShareButtonProps {
 }
 
 export const ShareButton: Component<ShareButtonProps> = props => {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const computedProps = mergeProps({showLabel: false, props});
   const [support, shareable, share] = useWebshare();
   const canShare = createMemo(() => support() && shareable(getData()));

--- a/apps/codeimage/src/index.tsx
+++ b/apps/codeimage/src/index.tsx
@@ -16,7 +16,6 @@ import './assets/styles/app.scss';
 import {SidebarPopoverHost} from './components/PropertyEditor/SidebarPopoverHost';
 import {Scaffold} from './components/Scaffold/Scaffold';
 import {locale} from './i18n';
-import {Editor} from './pages/Editor/Editor';
 import {darkGrayScale} from './theme/dark-theme.css';
 import './theme/dark-theme.css';
 import './theme/global.css';

--- a/apps/codeimage/src/pages/Dashboard/Dashboard.css.ts
+++ b/apps/codeimage/src/pages/Dashboard/Dashboard.css.ts
@@ -1,4 +1,4 @@
-import {adaptiveFullScreenHeight, textStyles, themeVars} from '@codeimage/ui';
+import {adaptiveFullScreenHeight, themeVars} from '@codeimage/ui';
 import {style} from '@vanilla-extract/css';
 
 export const scaffold = style([

--- a/apps/codeimage/src/pages/Dashboard/components/ProjectItem/ProjectItem.css.ts
+++ b/apps/codeimage/src/pages/Dashboard/components/ProjectItem/ProjectItem.css.ts
@@ -10,7 +10,7 @@ export const item = style({
   height: '128px',
   // boxShadow: themeVars.dynamicColors.dialog.panelShadow,
   boxShadow: 'inset 0 1px 0 0 rgb(255 255 255 / 5%)',
-  color: themeVars.dynamicColors.textColor,
+  color: themeVars.dynamicColors.baseText,
   transition: 'background-color 0.2s ease-in-out',
   position: 'relative',
   display: 'inline-flex',

--- a/apps/codeimage/src/pages/Editor/App.tsx
+++ b/apps/codeimage/src/pages/Editor/App.tsx
@@ -1,4 +1,3 @@
-import {createEditorSyncAdapter} from '@codeimage/store/editor/createEditorInit';
 import {getFrameState} from '@codeimage/store/editor/frame';
 import {Box, Button, HStack, PortalHost} from '@codeimage/ui';
 import {useModality} from '@core/hooks/isMobile';
@@ -65,7 +64,7 @@ export function App() {
                 </Button>
                 <div style={{flex: 1}} />
                 <ShareButton showLabel={true} />
-                <ExportInNewTabButton />
+                <ExportInNewTabButton canvasRef={frameRef()} />
               </HStack>
             </Box>
           </Show>

--- a/apps/codeimage/src/state/editor/editor.ts
+++ b/apps/codeimage/src/state/editor/editor.ts
@@ -1,4 +1,4 @@
-import {GetProjectByIdApi} from '@codeimage/api/api-types';
+import type * as ApiTypes from '@codeimage/api/api-types';
 import {
   createDerivedObservable,
   createDerivedSetter,
@@ -122,7 +122,7 @@ export function createEditorsStore() {
     () => filter(SUPPORTED_FONTS, font => font.id === state.options.fontId)[0],
   );
 
-  const setFromWorkspace = (item: GetProjectByIdApi['response']) => {
+  const setFromWorkspace = (item: ApiTypes.GetProjectByIdApi['response']) => {
     setEditors(
       item.editorTabs.map(
         editor =>

--- a/apps/codeimage/src/ui/ConfirmDialog/RenameContentDialog.tsx
+++ b/apps/codeimage/src/ui/ConfirmDialog/RenameContentDialog.tsx
@@ -7,7 +7,6 @@ import {
   FieldLabel,
   FlexField,
   HStack,
-  Text,
   TextField,
 } from '@codeimage/ui';
 import {

--- a/packages/atomic-state/tsconfig.dts.json
+++ b/packages/atomic-state/tsconfig.dts.json
@@ -2,7 +2,8 @@
     "extends": "./tsconfig.json",
     "compilerOptions": {
       "declaration": true,
-      "declarationMap": true,
+      "declarationMap": false,
+      "emitDeclarationOnly": true,
       "outDir": "./dist/types"
     }
   }

--- a/packages/config/tsconfig.dts.json
+++ b/packages/config/tsconfig.dts.json
@@ -3,6 +3,7 @@
     "compilerOptions": {
       "declaration": true,
       "declarationMap": false,
-      "outDir": "./dist/types"
+      "emitDeclarationOnly": true,
+      "outDir": "./dist"
     }
   }

--- a/packages/dom-export/tsconfig.dts.json
+++ b/packages/dom-export/tsconfig.dts.json
@@ -2,7 +2,7 @@
     "extends": "./tsconfig.json",
     "compilerOptions": {
       "declaration": true,
-      "declarationMap": true,
+      "declarationMap": false,
       "emitDeclarationOnly": true,
       "outDir": "./dist"
     }

--- a/packages/locale/tsconfig.dts.json
+++ b/packages/locale/tsconfig.dts.json
@@ -2,7 +2,7 @@
     "extends": "./tsconfig.json",
     "compilerOptions": {
       "declaration": true,
-      "declarationMap": true,
+      "declarationMap": false,
       "emitDeclarationOnly": true,
       "outDir": "./dist"
     }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -18,6 +18,7 @@
   },
   "scripts": {
     "build": "rollup -c",
+    "build:vite": "vite build",
     "build:watch": "vite build --watch",
     "pre-commit": "lint-staged --relative",
     "pre-commit-prettier": "prettier --write",

--- a/packages/ui/src/lib/primitives/Menu/DropdownMenuV2.tsx
+++ b/packages/ui/src/lib/primitives/Menu/DropdownMenuV2.tsx
@@ -26,7 +26,7 @@ import {CustomComponentProps, styled} from '../../utils';
 import {MenuPopup} from './MenuPopup';
 
 type DropdownMenuProps = FlowProps<
-  AriaMenuTriggerProps & AriaMenuProps & {menuButton: JSX.Element}
+  AriaMenuTriggerProps & AriaMenuProps & {menuButton?: JSX.Element}
 >;
 
 interface DropdownMenuContext {
@@ -39,7 +39,7 @@ interface DropdownMenuContext {
 const DropdownContext = createContext<DropdownMenuContext>();
 
 export function MenuButton<T extends ElementType>(
-  props: CustomComponentProps<T, DropdownMenuProps>,
+  props: CustomComponentProps<T, Omit<DropdownMenuProps, 'menuButton'>>,
 ) {
   const context = useContext(DropdownContext) as DropdownMenuContext;
   const {buttonProps} = createButton(

--- a/packages/ui/tsconfig.dts.json
+++ b/packages/ui/tsconfig.dts.json
@@ -2,7 +2,7 @@
     "extends": "./tsconfig.json",
     "compilerOptions": {
       "declaration": true,
-      "declarationMap": true,
+      "declarationMap": false,
       "emitDeclarationOnly": true,
       "outDir": "./dist/types"
     }

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -7,6 +7,7 @@
     "resolveJsonModule": true,
     "jsxImportSource": "solid-js",
     "preserveSymlinks": true,
+    "types": ["@types/node"]
   },
   "include": [
     "./src"

--- a/packages/ui/vite.config.ts
+++ b/packages/ui/vite.config.ts
@@ -13,6 +13,7 @@ const externals = [
 
 export function removeSideEffects(): Plugin {
   return {
+    name: 'fix-treeshaking',
     transform() {
       return {
         moduleSideEffects: 'no-treeshake',
@@ -27,16 +28,17 @@ export default defineConfig({
     dts({
       skipDiagnostics: false,
       logDiagnostics: true,
+      outputDir: './dist/types',
     }),
     // TODO: check possible issues --> why solid-js and @vanilla-extract/dynamic are imported in some files?
     removeSideEffects(),
   ],
   build: {
     lib: {
-      entry: resolve(__dirname, 'src/index.ts'),
+      entry: resolve(__dirname, 'src/index.tsx'),
       name: '@codeimage/ui',
       fileName: 'ui',
-      formats: ['es'],
+      formats: ['es', 'cjs'],
     },
     target: 'esnext',
     rollupOptions: {
@@ -44,7 +46,6 @@ export default defineConfig({
       output: {
         entryFileNames: '[name].js',
         preserveModules: true,
-        format: 'es',
       },
     },
   },


### PR DESCRIPTION
this fixes @codeimage/ui types using rollup overriding the default solid preset and all typecheck steps for ci
- fixes ci configuration in order to build types without bundling js
- fix lint errors
- fix type errors