### PR TITLE
feat(api): core custom error handling

### DIFF
--- a/apps/api/src/common/exceptions/entityNotUpdatableException.ts
+++ b/apps/api/src/common/exceptions/entityNotUpdatableException.ts
@@ -1,0 +1,7 @@
+import {HandlerError} from './handlerError';
+
+export class EntityNotUpdatableException extends HandlerError<{code: string}> {
+  createMessage(args: {code: string}): string {
+    return `Entity with id ${args.code} not updatable`;
+  }
+}

--- a/apps/api/src/common/exceptions/entityNotUpdatableException.ts
+++ b/apps/api/src/common/exceptions/entityNotUpdatableException.ts
@@ -1,7 +1,9 @@
 import {HandlerError} from './handlerError';
 
-export class EntityNotUpdatableException extends HandlerError<{code: string}> {
-  createMessage(args: {code: string}): string {
-    return `Entity with id ${args.code} not updatable`;
+export class EntityNotUpdatableException<
+  Args extends Record<string, string | number> | void = void,
+> extends HandlerError<Args> {
+  createMessage(): string {
+    return `Cannot update given entity`;
   }
 }

--- a/apps/api/src/common/exceptions/forbiddenEntityException.ts
+++ b/apps/api/src/common/exceptions/forbiddenEntityException.ts
@@ -1,6 +1,8 @@
 import {HandlerError} from './handlerError';
 
-export class ForbiddenEntityException extends HandlerError {
+export class ForbiddenEntityException<
+  Args extends Record<string, string | number> | void = void,
+> extends HandlerError<Args> {
   createMessage(): string {
     return 'Entity not accessible';
   }

--- a/apps/api/src/common/exceptions/forbiddenEntityException.ts
+++ b/apps/api/src/common/exceptions/forbiddenEntityException.ts
@@ -1,0 +1,7 @@
+import {HandlerError} from './handlerError';
+
+export class ForbiddenEntityException extends HandlerError {
+  createMessage(): string {
+    return 'Entity not accessible';
+  }
+}

--- a/apps/api/src/common/exceptions/handlerError.ts
+++ b/apps/api/src/common/exceptions/handlerError.ts
@@ -1,4 +1,11 @@
 import {FastifyError} from 'fastify';
+import {constants} from 'http2';
+
+type HttpStatusCode = {
+  readonly [K in keyof typeof constants as K extends `HTTP_STATUS_${string}`
+    ? K
+    : never]: typeof constants[K];
+};
 
 export abstract class HandlerError<
     Args extends Record<string, string | number> | void = void,
@@ -8,9 +15,11 @@ export abstract class HandlerError<
 {
   code = this.constructor.name;
 
-  constructor(args: Args) {
+  static httpStatusCode = constants as HttpStatusCode;
+
+  constructor(args?: Args) {
     super();
-    this.message = this.createMessage(args);
+    this.message = this.createMessage(args as Args);
     Error.captureStackTrace(this, this.constructor);
   }
 

--- a/apps/api/src/common/exceptions/handlerError.ts
+++ b/apps/api/src/common/exceptions/handlerError.ts
@@ -1,0 +1,18 @@
+import {FastifyError} from 'fastify';
+
+export abstract class HandlerError<
+    Args extends Record<string, string | number> | void = void,
+  >
+  extends Error
+  implements FastifyError
+{
+  code = this.constructor.name;
+
+  constructor(args: Args) {
+    super();
+    this.message = this.createMessage(args);
+    Error.captureStackTrace(this, this.constructor);
+  }
+
+  abstract createMessage(args: Args): string;
+}

--- a/apps/api/src/common/exceptions/notFoundEntityException.ts
+++ b/apps/api/src/common/exceptions/notFoundEntityException.ts
@@ -1,6 +1,8 @@
 import {HandlerError} from './handlerError';
 
-export class NotFoundEntityException extends HandlerError {
+export class NotFoundEntityException<
+  Args extends Record<string, string | number> | void = void,
+> extends HandlerError<Args> {
   createMessage(): string {
     return 'Resource not found';
   }

--- a/apps/api/src/common/exceptions/notFoundEntityException.ts
+++ b/apps/api/src/common/exceptions/notFoundEntityException.ts
@@ -1,0 +1,7 @@
+import {HandlerError} from './handlerError';
+
+export class NotFoundEntityException extends HandlerError {
+  createMessage(): string {
+    return 'Resource not found';
+  }
+}

--- a/apps/api/src/plugins/handlerErrors.ts
+++ b/apps/api/src/plugins/handlerErrors.ts
@@ -4,36 +4,41 @@ import {EntityNotUpdatableException} from '../common/exceptions/entityNotUpdatab
 import {ForbiddenEntityException} from '../common/exceptions/forbiddenEntityException';
 import {NotFoundEntityException} from '../common/exceptions/notFoundEntityException';
 
-export default fp(async fastify => {
-  fastify.setErrorHandler(error => {
-    let httpError: HttpError | null = null;
+export default fp(
+  async fastify => {
+    fastify.setErrorHandler(error => {
+      let httpError: HttpError | null = null;
 
-    if (error.statusCode) {
-      httpError = fastify.httpErrors.createError(
-        error.statusCode,
-        error.message,
-      );
-    } else {
-      if (error instanceof NotFoundEntityException) {
-        httpError = fastify.httpErrors.notFound(error.message);
+      if (error.statusCode) {
+        httpError = fastify.httpErrors.createError(
+          error.statusCode,
+          error.message,
+        );
+      } else {
+        if (error instanceof NotFoundEntityException) {
+          httpError = fastify.httpErrors.notFound(error.message);
+        }
+
+        if (error instanceof ForbiddenEntityException) {
+          httpError = fastify.httpErrors.forbidden(error.message);
+        }
+
+        if (error instanceof EntityNotUpdatableException) {
+          httpError = fastify.httpErrors.badRequest(error.message);
+        }
       }
 
-      if (error instanceof ForbiddenEntityException) {
-        httpError = fastify.httpErrors.forbidden(error.message);
+      if (httpError) {
+        httpError.stack = error.stack;
+        httpError.code = error.code;
+
+        return httpError;
       }
 
-      if (error instanceof EntityNotUpdatableException) {
-        httpError = fastify.httpErrors.badRequest(error.message);
-      }
-    }
+      return error;
+    });
 
-    if (httpError) {
-      httpError.stack = error.stack;
-      httpError.code = error.code;
-
-      return httpError;
-    }
-
-    return error;
-  });
-});
+    return;
+  },
+  {name: 'appErrorsHandler'},
+);

--- a/apps/api/src/plugins/handlerErrors.ts
+++ b/apps/api/src/plugins/handlerErrors.ts
@@ -8,16 +8,23 @@ export default fp(async fastify => {
   fastify.setErrorHandler(error => {
     let httpError: HttpError | null = null;
 
-    if (error instanceof NotFoundEntityException) {
-      httpError = fastify.httpErrors.notFound(error.message);
-    }
+    if (error.statusCode) {
+      httpError = fastify.httpErrors.createError(
+        error.statusCode,
+        error.message,
+      );
+    } else {
+      if (error instanceof NotFoundEntityException) {
+        httpError = fastify.httpErrors.notFound(error.message);
+      }
 
-    if (error instanceof ForbiddenEntityException) {
-      httpError = fastify.httpErrors.forbidden(error.message);
-    }
+      if (error instanceof ForbiddenEntityException) {
+        httpError = fastify.httpErrors.forbidden(error.message);
+      }
 
-    if (error instanceof EntityNotUpdatableException) {
-      httpError = fastify.httpErrors.badRequest(error.message);
+      if (error instanceof EntityNotUpdatableException) {
+        httpError = fastify.httpErrors.badRequest(error.message);
+      }
     }
 
     if (httpError) {

--- a/apps/api/src/plugins/handlerErrors.ts
+++ b/apps/api/src/plugins/handlerErrors.ts
@@ -1,0 +1,32 @@
+import {HttpError} from '@fastify/sensible/lib/httpError';
+import fp from 'fastify-plugin';
+import {EntityNotUpdatableException} from '../common/exceptions/entityNotUpdatableException';
+import {ForbiddenEntityException} from '../common/exceptions/forbiddenEntityException';
+import {NotFoundEntityException} from '../common/exceptions/notFoundEntityException';
+
+export default fp(async fastify => {
+  fastify.setErrorHandler(error => {
+    let httpError: HttpError | null = null;
+
+    if (error instanceof NotFoundEntityException) {
+      httpError = fastify.httpErrors.notFound(error.message);
+    }
+
+    if (error instanceof ForbiddenEntityException) {
+      httpError = fastify.httpErrors.forbidden(error.message);
+    }
+
+    if (error instanceof EntityNotUpdatableException) {
+      httpError = fastify.httpErrors.badRequest(error.message);
+    }
+
+    if (httpError) {
+      httpError.stack = error.stack;
+      httpError.code = error.code;
+
+      return httpError;
+    }
+
+    return error;
+  });
+});

--- a/apps/api/test/plugins/handlerErrors.test.ts
+++ b/apps/api/test/plugins/handlerErrors.test.ts
@@ -1,0 +1,45 @@
+import {fastifySensible} from '@fastify/sensible';
+import Fastify from 'fastify';
+import fp from 'fastify-plugin';
+import t from 'tap';
+import {HandlerError} from '../../src/common/exceptions/handlerError';
+import handlerErrors from '../../src/plugins/handlerErrors';
+
+async function build(t: Tap.Test, response: () => unknown) {
+  const app = Fastify();
+  await void app.register(
+    fp(async app => {
+      await app.register(fastifySensible);
+      await app.register(handlerErrors);
+    }),
+  );
+  app.get('/', async _ => response());
+  await app.ready();
+  t.teardown(() => void app.close());
+  return app;
+}
+
+t.test('should throw exception by status code', async t => {
+  class DomainNotValid extends HandlerError {
+    statusCode = HandlerError.httpStatusCode.HTTP_STATUS_BAD_REQUEST;
+
+    createMessage(): string {
+      return 'Domain not valid';
+    }
+  }
+
+  const app = await build(t, () => {
+    throw new DomainNotValid();
+  });
+
+  const response = await app.inject({
+    method: 'GET',
+    path: '/',
+  });
+
+  const json = response.json<{code: string; message: string}>();
+
+  t.equal(response.statusCode, 400);
+  t.equal(json.code, 'DomainNotValid');
+  t.equal(json.message, 'Domain not valid');
+});


### PR DESCRIPTION
Add custom error handling to api module

### Create custom errors

```ts
class PresetNotFoundException extends NotFoundEntityException<{id: string}> { 
  createMessage(args: { id: string }) {
    return `Preset with id ${id} not found`
  }
}
```

Then in your handler

```ts
async findById(id: string) { 
  const preset = ...
  if (!preset) { 
    throw new PresetNotFoundException({ id })
  }
}


```
