### PR TITLE
feat: customizable export options

### DIFF
--- a/.changeset/witty-nails-return.md
+++ b/.changeset/witty-nails-return.md
@@ -1,0 +1,6 @@
+---
+"@codeimage/app": minor
+"@codeimage/dom-export": patch
+---
+
+feat: customizable export options

--- a/apps/codeimage/src/components/PropertyEditor/controls/CustomColorPicker.tsx
+++ b/apps/codeimage/src/components/PropertyEditor/controls/CustomColorPicker.tsx
@@ -39,7 +39,7 @@ export function CustomColorPicker(props: CustomColorPickerProps) {
         </As>
       </PopoverTrigger>
       <PopoverContent variant={'bordered'} class={styles.popover}>
-        <DynamicSizedContainer enabled={modality === 'full'}>
+        <DynamicSizedContainer>
           <Box
             display={'flex'}
             justifyContent={'spaceBetween'}

--- a/apps/codeimage/src/components/Toolbar/CopyToClipboardButton.tsx
+++ b/apps/codeimage/src/components/Toolbar/CopyToClipboardButton.tsx
@@ -1,8 +1,17 @@
 import {dispatchCopyToClipboard} from '@codeimage/store/effects/onCopyToClipboard';
-import {LoadingCircle} from '@codeimage/ui';
-import {Button} from '@codeui/kit';
+import {LoadingCircle, SvgIcon} from '@codeimage/ui';
+import {
+  Button,
+  IconButton,
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@codeui/kit';
+import {As} from '@kobalte/core';
 import {Component} from 'solid-js';
 import {ClipboardIcon} from '../Icons/Clipboard';
+import {ExportDialog} from './ExportButton';
+import {ExportPopoverContent} from './ExportContent';
 
 interface ExportButtonProps {
   canvasRef: HTMLElement | undefined;
@@ -19,20 +28,46 @@ export const CopyToClipboardButton: Component<ExportButtonProps> = props => {
   }
 
   return (
-    <Button
-      theme={'secondary'}
-      disabled={dispatchCopyToClipboard.loading()}
-      leftIcon={
-        dispatchCopyToClipboard.loading() ? (
-          <LoadingCircle size={'xs'} />
-        ) : (
-          <ClipboardIcon />
-        )
-      }
-      onClick={copyToClipboard}
-      size={'xs'}
-    >
-      {label()}
-    </Button>
+    <>
+      <div style={{display: 'flex'}}>
+        <Button
+          theme={'secondary'}
+          loading={dispatchCopyToClipboard.loading()}
+          style={{
+            'border-bottom-right-radius': 0,
+            'border-top-right-radius': 0,
+          }}
+          onClick={copyToClipboard}
+          size={'xs'}
+        >
+          {label()}
+        </Button>
+        <Popover placement={'bottom-end'}>
+          <PopoverTrigger asChild>
+            <As
+              component={IconButton}
+              aria-label={'hint'}
+              size={'xs'}
+              theme={'secondary'}
+              style={{
+                'border-bottom-left-radius': 0,
+                'border-top-left-radius': 0,
+                'border-left': '1px solid rgba(0,0,0,.20)',
+              }}
+            >
+              <SvgIcon
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                fill="currentColor"
+                class="w-6 h-6"
+              >
+                <path d="M18.75 12.75h1.5a.75.75 0 000-1.5h-1.5a.75.75 0 000 1.5zM12 6a.75.75 0 01.75-.75h7.5a.75.75 0 010 1.5h-7.5A.75.75 0 0112 6zM12 18a.75.75 0 01.75-.75h7.5a.75.75 0 010 1.5h-7.5A.75.75 0 0112 18zM3.75 6.75h1.5a.75.75 0 100-1.5h-1.5a.75.75 0 000 1.5zM5.25 18.75h-1.5a.75.75 0 010-1.5h1.5a.75.75 0 010 1.5zM3 12a.75.75 0 01.75-.75h7.5a.75.75 0 010 1.5h-7.5A.75.75 0 013 12zM9 3.75a2.25 2.25 0 100 4.5 2.25 2.25 0 000-4.5zM12.75 12a2.25 2.25 0 114.5 0 2.25 2.25 0 01-4.5 0zM9 15.75a2.25 2.25 0 100 4.5 2.25 2.25 0 000-4.5z" />
+              </SvgIcon>
+            </As>
+          </PopoverTrigger>
+          <ExportPopoverContent onConfirm={() => void 0} />
+        </Popover>
+      </div>
+    </>
   );
 };

--- a/apps/codeimage/src/components/Toolbar/CopyToClipboardButton.tsx
+++ b/apps/codeimage/src/components/Toolbar/CopyToClipboardButton.tsx
@@ -1,17 +1,6 @@
 import {dispatchCopyToClipboard} from '@codeimage/store/effects/onCopyToClipboard';
-import {LoadingCircle, SvgIcon} from '@codeimage/ui';
-import {
-  Button,
-  IconButton,
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from '@codeui/kit';
-import {As} from '@kobalte/core';
+import {Button} from '@codeui/kit';
 import {Component} from 'solid-js';
-import {ClipboardIcon} from '../Icons/Clipboard';
-import {ExportDialog} from './ExportButton';
-import {ExportPopoverContent} from './ExportContent';
 
 interface ExportButtonProps {
   canvasRef: HTMLElement | undefined;
@@ -28,46 +17,13 @@ export const CopyToClipboardButton: Component<ExportButtonProps> = props => {
   }
 
   return (
-    <>
-      <div style={{display: 'flex'}}>
-        <Button
-          theme={'secondary'}
-          loading={dispatchCopyToClipboard.loading()}
-          style={{
-            'border-bottom-right-radius': 0,
-            'border-top-right-radius': 0,
-          }}
-          onClick={copyToClipboard}
-          size={'xs'}
-        >
-          {label()}
-        </Button>
-        <Popover placement={'bottom-end'}>
-          <PopoverTrigger asChild>
-            <As
-              component={IconButton}
-              aria-label={'hint'}
-              size={'xs'}
-              theme={'secondary'}
-              style={{
-                'border-bottom-left-radius': 0,
-                'border-top-left-radius': 0,
-                'border-left': '1px solid rgba(0,0,0,.20)',
-              }}
-            >
-              <SvgIcon
-                xmlns="http://www.w3.org/2000/svg"
-                viewBox="0 0 24 24"
-                fill="currentColor"
-                class="w-6 h-6"
-              >
-                <path d="M18.75 12.75h1.5a.75.75 0 000-1.5h-1.5a.75.75 0 000 1.5zM12 6a.75.75 0 01.75-.75h7.5a.75.75 0 010 1.5h-7.5A.75.75 0 0112 6zM12 18a.75.75 0 01.75-.75h7.5a.75.75 0 010 1.5h-7.5A.75.75 0 0112 18zM3.75 6.75h1.5a.75.75 0 100-1.5h-1.5a.75.75 0 000 1.5zM5.25 18.75h-1.5a.75.75 0 010-1.5h1.5a.75.75 0 010 1.5zM3 12a.75.75 0 01.75-.75h7.5a.75.75 0 010 1.5h-7.5A.75.75 0 013 12zM9 3.75a2.25 2.25 0 100 4.5 2.25 2.25 0 000-4.5zM12.75 12a2.25 2.25 0 114.5 0 2.25 2.25 0 01-4.5 0zM9 15.75a2.25 2.25 0 100 4.5 2.25 2.25 0 000-4.5z" />
-              </SvgIcon>
-            </As>
-          </PopoverTrigger>
-          <ExportPopoverContent onConfirm={() => void 0} />
-        </Popover>
-      </div>
-    </>
+    <Button
+      theme={'secondary'}
+      loading={dispatchCopyToClipboard.loading()}
+      onClick={copyToClipboard}
+      size={'xs'}
+    >
+      {label()}
+    </Button>
   );
 };

--- a/apps/codeimage/src/components/Toolbar/ExportContent.css.ts
+++ b/apps/codeimage/src/components/Toolbar/ExportContent.css.ts
@@ -1,0 +1,9 @@
+import {style} from '@vanilla-extract/css';
+
+export const exportContent = style({
+  width: '240px',
+});
+
+export const exportContentPopover = style({
+  maxWidth: 'unset',
+});

--- a/apps/codeimage/src/components/Toolbar/ExportContent.tsx
+++ b/apps/codeimage/src/components/Toolbar/ExportContent.tsx
@@ -12,16 +12,15 @@ import {
   Text,
   VStack,
 } from '@codeimage/ui';
-import {DialogProps, PopoverContent} from '@codeui/kit';
+import {PopoverContent} from '@codeui/kit';
 import {DynamicSizedContainer} from '@ui/DynamicSizedContainer/DynamicSizedContainer';
 import {createSignal, Show} from 'solid-js';
 import {ExportExtension} from '../../hooks/use-export-image';
 import {AppLocaleEntries} from '../../i18n';
 import {ExclamationIcon} from '../Icons/Exclamation';
-import {ExportDialogProps} from './ExportButton';
 import * as styles from './ExportContent.css';
 
-export function ExportPopoverContent(props: ExportDialogProps & DialogProps) {
+export function ExportPopoverContent() {
   const [t] = useI18n<AppLocaleEntries>();
   const exportCanvasStore = getExportCanvasStore();
   const [quality, setQuality] = createSignal<number>(100);

--- a/apps/codeimage/src/components/Toolbar/ExportContent.tsx
+++ b/apps/codeimage/src/components/Toolbar/ExportContent.tsx
@@ -1,0 +1,130 @@
+import {useI18n} from '@codeimage/locale';
+import {canvasSize} from '@codeimage/store/canvas';
+import {
+  Box,
+  FieldLabel,
+  FieldLabelHint,
+  FlexField,
+  HStack,
+  Link,
+  RangeField,
+  SegmentedField,
+  SegmentedFieldItem,
+  Text,
+  VStack,
+} from '@codeimage/ui';
+import {DialogProps, PopoverContent, TextField} from '@codeui/kit';
+import {useWebshare} from '@core/hooks/use-webshare';
+import {createSignal, onMount, Show} from 'solid-js';
+import {ExportExtension, ExportMode} from '../../hooks/use-export-image';
+import {AppLocaleEntries} from '../../i18n';
+import {ExclamationIcon} from '../Icons/Exclamation';
+import {HintIcon} from '../Icons/Hint';
+import {ExportDialogProps} from './ExportButton';
+
+export function ExportPopoverContent(props: ExportDialogProps & DialogProps) {
+  const [t] = useI18n<AppLocaleEntries>();
+  const [supportWebShare] = useWebshare();
+  const [mode, setMode] = createSignal<ExportMode>(ExportMode.share);
+  const [extension, setExtension] = createSignal<ExportExtension>(
+    ExportExtension.png,
+  );
+
+  const [quality, setQuality] = createSignal<number>(100);
+
+  const [devicePixelRatio, setDevicePixelRatio] = createSignal<number>(
+    Math.round(window.devicePixelRatio),
+  );
+
+  const extensionItems: SegmentedFieldItem<ExportExtension>[] = [
+    {label: 'PNG', value: ExportExtension.png},
+    {label: 'SVG', value: ExportExtension.svg},
+    {label: 'JPEG', value: ExportExtension.jpeg},
+  ];
+
+  onMount(() => {
+    if (!supportWebShare()) {
+      setMode(ExportMode.export);
+    }
+  });
+
+  const canvasResolution = () => {
+    const height = Math.ceil(canvasSize.canvasHeight) * devicePixelRatio();
+    const width = Math.ceil(canvasSize.canvasWidth) * devicePixelRatio();
+    return `${width}x${height}`;
+  };
+
+  return (
+    <PopoverContent title={'Export Settings'}>
+      <VStack spacing={'6'} marginTop={2}>
+        <FlexField size={'md'}>
+          <FieldLabel size={'sm'}>{t('export.extensionType')}</FieldLabel>
+          <SegmentedField
+            value={extension()}
+            onChange={setExtension}
+            items={extensionItems}
+          />
+          <Show when={extension() === 'jpeg'}>
+            <Box marginTop={1}>
+              <FieldLabelHint
+                size={'sm'}
+                weight={'normal'}
+                icon={() => <ExclamationIcon size={'sm'} />}
+              >
+                {t('export.noOpacitySupportedWithThisExtension')}
+                &nbsp;
+              </FieldLabelHint>
+            </Box>
+          </Show>
+        </FlexField>
+
+        <Show when={extension() === 'jpeg'}>
+          <FlexField size={'md'}>
+            <FieldLabel size={'sm'}>
+              {t('export.quality')}
+              <Box as={'span'} marginLeft={3}>
+                <FieldLabelHint>{quality()}%</FieldLabelHint>
+              </Box>
+            </FieldLabel>
+            <RangeField
+              value={quality()}
+              onChange={setQuality}
+              max={100}
+              min={70}
+              step={2}
+            />
+          </FlexField>
+        </Show>
+
+        <FlexField size={'md'}>
+          <FieldLabel size={'sm'}>
+            {t('export.pixelRatio')}
+            <Box as={'span'} marginLeft={3}>
+              <FieldLabelHint>{devicePixelRatio()}x</FieldLabelHint>
+            </Box>
+          </FieldLabel>
+          <SegmentedField
+            value={devicePixelRatio()}
+            onChange={setDevicePixelRatio}
+            items={[
+              {label: '1x', value: 1},
+              {label: '2x', value: 2},
+              {label: '3x', value: 3},
+            ]}
+          />
+
+          <HStack
+            spacing={6}
+            marginTop={5}
+            display={'flex'}
+            justifyContent={'spaceBetween'}
+            alignItems={'center'}
+          >
+            <Text size={'sm'}>Output resolution</Text>
+            <Box marginLeft={'auto'}>{canvasResolution()}</Box>
+          </HStack>
+        </FlexField>
+      </VStack>
+    </PopoverContent>
+  );
+}

--- a/apps/codeimage/src/components/Toolbar/ExportContent.tsx
+++ b/apps/codeimage/src/components/Toolbar/ExportContent.tsx
@@ -37,7 +37,7 @@ export function ExportPopoverContent(props: ExportDialogProps & DialogProps) {
       title={'Export Settings'}
       class={styles.exportContentPopover}
     >
-      <DynamicSizedContainer enabled={true}>
+      <DynamicSizedContainer>
         <div class={styles.exportContent}>
           <VStack spacing={'6'} marginTop={2} width={'100%'}>
             <FlexField size={'md'}>

--- a/apps/codeimage/src/components/Toolbar/ExportContent.tsx
+++ b/apps/codeimage/src/components/Toolbar/ExportContent.tsx
@@ -1,40 +1,30 @@
 import {useI18n} from '@codeimage/locale';
-import {canvasSize} from '@codeimage/store/canvas';
+import {getExportCanvasStore} from '@codeimage/store/canvas';
 import {
   Box,
   FieldLabel,
   FieldLabelHint,
   FlexField,
   HStack,
-  Link,
   RangeField,
   SegmentedField,
   SegmentedFieldItem,
   Text,
   VStack,
 } from '@codeimage/ui';
-import {DialogProps, PopoverContent, TextField} from '@codeui/kit';
-import {useWebshare} from '@core/hooks/use-webshare';
-import {createSignal, onMount, Show} from 'solid-js';
-import {ExportExtension, ExportMode} from '../../hooks/use-export-image';
+import {DialogProps, PopoverContent} from '@codeui/kit';
+import {DynamicSizedContainer} from '@ui/DynamicSizedContainer/DynamicSizedContainer';
+import {createSignal, Show} from 'solid-js';
+import {ExportExtension} from '../../hooks/use-export-image';
 import {AppLocaleEntries} from '../../i18n';
 import {ExclamationIcon} from '../Icons/Exclamation';
-import {HintIcon} from '../Icons/Hint';
 import {ExportDialogProps} from './ExportButton';
+import * as styles from './ExportContent.css';
 
 export function ExportPopoverContent(props: ExportDialogProps & DialogProps) {
   const [t] = useI18n<AppLocaleEntries>();
-  const [supportWebShare] = useWebshare();
-  const [mode, setMode] = createSignal<ExportMode>(ExportMode.share);
-  const [extension, setExtension] = createSignal<ExportExtension>(
-    ExportExtension.png,
-  );
-
+  const exportCanvasStore = getExportCanvasStore();
   const [quality, setQuality] = createSignal<number>(100);
-
-  const [devicePixelRatio, setDevicePixelRatio] = createSignal<number>(
-    Math.round(window.devicePixelRatio),
-  );
 
   const extensionItems: SegmentedFieldItem<ExportExtension>[] = [
     {label: 'PNG', value: ExportExtension.png},
@@ -42,89 +32,91 @@ export function ExportPopoverContent(props: ExportDialogProps & DialogProps) {
     {label: 'JPEG', value: ExportExtension.jpeg},
   ];
 
-  onMount(() => {
-    if (!supportWebShare()) {
-      setMode(ExportMode.export);
-    }
-  });
-
-  const canvasResolution = () => {
-    const height = Math.ceil(canvasSize.canvasHeight) * devicePixelRatio();
-    const width = Math.ceil(canvasSize.canvasWidth) * devicePixelRatio();
-    return `${width}x${height}`;
-  };
-
   return (
-    <PopoverContent title={'Export Settings'}>
-      <VStack spacing={'6'} marginTop={2}>
-        <FlexField size={'md'}>
-          <FieldLabel size={'sm'}>{t('export.extensionType')}</FieldLabel>
-          <SegmentedField
-            value={extension()}
-            onChange={setExtension}
-            items={extensionItems}
-          />
-          <Show when={extension() === 'jpeg'}>
-            <Box marginTop={1}>
-              <FieldLabelHint
-                size={'sm'}
-                weight={'normal'}
-                icon={() => <ExclamationIcon size={'sm'} />}
+    <PopoverContent
+      title={'Export Settings'}
+      class={styles.exportContentPopover}
+    >
+      <DynamicSizedContainer enabled={true}>
+        <div class={styles.exportContent}>
+          <VStack spacing={'6'} marginTop={2} width={'100%'}>
+            <FlexField size={'md'}>
+              <FieldLabel size={'sm'}>{t('export.extensionType')}</FieldLabel>
+              <SegmentedField
+                value={exportCanvasStore.get.extension}
+                onChange={value => exportCanvasStore.set('extension', value)}
+                items={extensionItems}
+              />
+              <Show when={exportCanvasStore.get.extension === 'jpeg'}>
+                <Box marginTop={1}>
+                  <FieldLabelHint
+                    size={'sm'}
+                    weight={'normal'}
+                    icon={() => <ExclamationIcon size={'sm'} />}
+                  >
+                    {t('export.noOpacitySupportedWithThisExtension')}
+                    &nbsp;
+                  </FieldLabelHint>
+                </Box>
+              </Show>
+            </FlexField>
+
+            <Show when={exportCanvasStore.get.extension === 'jpeg'}>
+              <FlexField size={'md'}>
+                <FieldLabel size={'sm'}>
+                  {t('export.quality')}
+                  <Box as={'span'} marginLeft={3}>
+                    <FieldLabelHint>{quality()}%</FieldLabelHint>
+                  </Box>
+                </FieldLabel>
+                <RangeField
+                  value={quality()}
+                  onChange={setQuality}
+                  max={100}
+                  min={70}
+                  step={2}
+                />
+              </FlexField>
+            </Show>
+
+            <FlexField size={'md'}>
+              <FieldLabel size={'sm'}>
+                {t('export.pixelRatio')}
+                <Box as={'span'} marginLeft={3}>
+                  <FieldLabelHint>
+                    {exportCanvasStore.get.devicePixelRatio}x
+                  </FieldLabelHint>
+                </Box>
+              </FieldLabel>
+              <SegmentedField
+                value={exportCanvasStore.get.devicePixelRatio}
+                onChange={value =>
+                  exportCanvasStore.set('devicePixelRatio', value)
+                }
+                items={[
+                  {label: '1x', value: 1},
+                  {label: '2x', value: 2},
+                  {label: '3x', value: 3},
+                  {label: '6x', value: 6},
+                ]}
+              />
+
+              <HStack
+                spacing={6}
+                marginTop={5}
+                display={'flex'}
+                justifyContent={'spaceBetween'}
+                alignItems={'center'}
               >
-                {t('export.noOpacitySupportedWithThisExtension')}
-                &nbsp;
-              </FieldLabelHint>
-            </Box>
-          </Show>
-        </FlexField>
-
-        <Show when={extension() === 'jpeg'}>
-          <FlexField size={'md'}>
-            <FieldLabel size={'sm'}>
-              {t('export.quality')}
-              <Box as={'span'} marginLeft={3}>
-                <FieldLabelHint>{quality()}%</FieldLabelHint>
-              </Box>
-            </FieldLabel>
-            <RangeField
-              value={quality()}
-              onChange={setQuality}
-              max={100}
-              min={70}
-              step={2}
-            />
-          </FlexField>
-        </Show>
-
-        <FlexField size={'md'}>
-          <FieldLabel size={'sm'}>
-            {t('export.pixelRatio')}
-            <Box as={'span'} marginLeft={3}>
-              <FieldLabelHint>{devicePixelRatio()}x</FieldLabelHint>
-            </Box>
-          </FieldLabel>
-          <SegmentedField
-            value={devicePixelRatio()}
-            onChange={setDevicePixelRatio}
-            items={[
-              {label: '1x', value: 1},
-              {label: '2x', value: 2},
-              {label: '3x', value: 3},
-            ]}
-          />
-
-          <HStack
-            spacing={6}
-            marginTop={5}
-            display={'flex'}
-            justifyContent={'spaceBetween'}
-            alignItems={'center'}
-          >
-            <Text size={'sm'}>Output resolution</Text>
-            <Box marginLeft={'auto'}>{canvasResolution()}</Box>
-          </HStack>
-        </FlexField>
-      </VStack>
+                <Text size={'sm'}>Output resolution</Text>
+                <Box marginLeft={'auto'}>
+                  {exportCanvasStore.canvasResolution()}
+                </Box>
+              </HStack>
+            </FlexField>
+          </VStack>
+        </div>
+      </DynamicSizedContainer>
     </PopoverContent>
   );
 }

--- a/apps/codeimage/src/components/Toolbar/ExportNewTabButton.tsx
+++ b/apps/codeimage/src/components/Toolbar/ExportNewTabButton.tsx
@@ -1,8 +1,15 @@
 import {useI18n} from '@codeimage/locale';
-import {toast} from '@codeimage/ui';
-import {Button} from '@codeui/kit';
+import {LoadingCircle, SvgIcon, toast} from '@codeimage/ui';
+import {
+  Button,
+  IconButton,
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@codeui/kit';
 import {getUmami} from '@core/constants/umami';
 import {useModality} from '@core/hooks/isMobile';
+import {As} from '@kobalte/core';
 import {Component, createEffect, untrack} from 'solid-js';
 import {
   ExportExtension,
@@ -11,7 +18,10 @@ import {
 } from '../../hooks/use-export-image';
 import {useHotkey} from '../../hooks/use-hotkey';
 import {AppLocaleEntries} from '../../i18n';
+import {DownloadIcon} from '../Icons/Download';
 import {ExternalLinkIcon} from '../Icons/ExternalLink';
+import {ExportDialog} from './ExportButton';
+import {ExportPopoverContent} from './ExportContent';
 
 interface ExportButtonProps {
   canvasRef: HTMLElement | undefined;
@@ -23,6 +33,8 @@ export const ExportInNewTabButton: Component<ExportButtonProps> = props => {
   const [t] = useI18n<AppLocaleEntries>();
 
   const [data, notify] = useExportImage();
+
+  const label = () => t('toolbar.openNewTab');
 
   function openInTab() {
     getUmami().trackEvent(`true`, 'export-new-tab');
@@ -63,14 +75,47 @@ export const ExportInNewTabButton: Component<ExportButtonProps> = props => {
   });
 
   return (
-    <Button
-      theme={'tertiary'}
-      loading={data.loading}
-      leftIcon={<ExternalLinkIcon />}
-      onClick={() => openInTab()}
-      size={props.size ?? (modality === 'full' ? 'sm' : 'xs')}
-    >
-      {t('toolbar.openNewTab')}
-    </Button>
+    <>
+      <div style={{display: 'flex'}}>
+        <Button
+          theme={'tertiary'}
+          leftIcon={<ExternalLinkIcon />}
+          loading={data.loading}
+          onClick={() => openInTab()}
+          size={props.size ?? (modality === 'full' ? 'sm' : 'xs')}
+          style={{
+            'border-bottom-right-radius': 0,
+            'border-top-right-radius': 0,
+          }}
+        >
+          {label()}
+        </Button>
+        <Popover placement={'bottom-end'}>
+          <PopoverTrigger asChild>
+            <As
+              component={IconButton}
+              aria-label={'hint'}
+              size={props.size ?? (modality === 'full' ? 'sm' : 'xs')}
+              theme={'tertiary'}
+              style={{
+                'border-bottom-left-radius': 0,
+                'border-top-left-radius': 0,
+                'border-left': '1px solid rgba(0,0,0,.20)',
+              }}
+            >
+              <SvgIcon
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                fill="currentColor"
+                class="w-6 h-6"
+              >
+                <path d="M18.75 12.75h1.5a.75.75 0 000-1.5h-1.5a.75.75 0 000 1.5zM12 6a.75.75 0 01.75-.75h7.5a.75.75 0 010 1.5h-7.5A.75.75 0 0112 6zM12 18a.75.75 0 01.75-.75h7.5a.75.75 0 010 1.5h-7.5A.75.75 0 0112 18zM3.75 6.75h1.5a.75.75 0 100-1.5h-1.5a.75.75 0 000 1.5zM5.25 18.75h-1.5a.75.75 0 010-1.5h1.5a.75.75 0 010 1.5zM3 12a.75.75 0 01.75-.75h7.5a.75.75 0 010 1.5h-7.5A.75.75 0 013 12zM9 3.75a2.25 2.25 0 100 4.5 2.25 2.25 0 000-4.5zM12.75 12a2.25 2.25 0 114.5 0 2.25 2.25 0 01-4.5 0zM9 15.75a2.25 2.25 0 100 4.5 2.25 2.25 0 000-4.5z" />
+              </SvgIcon>
+            </As>
+          </PopoverTrigger>
+          <ExportPopoverContent onConfirm={() => void 0} />
+        </Popover>
+      </div>
+    </>
   );
 };

--- a/apps/codeimage/src/components/Toolbar/ExportNewTabButton.tsx
+++ b/apps/codeimage/src/components/Toolbar/ExportNewTabButton.tsx
@@ -1,27 +1,14 @@
 import {useI18n} from '@codeimage/locale';
-import {LoadingCircle, SvgIcon, toast} from '@codeimage/ui';
-import {
-  Button,
-  IconButton,
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from '@codeui/kit';
+import {getExportCanvasStore} from '@codeimage/store/canvas';
+import {toast} from '@codeimage/ui';
+import {Button} from '@codeui/kit';
 import {getUmami} from '@core/constants/umami';
 import {useModality} from '@core/hooks/isMobile';
-import {As} from '@kobalte/core';
 import {Component, createEffect, untrack} from 'solid-js';
-import {
-  ExportExtension,
-  ExportMode,
-  useExportImage,
-} from '../../hooks/use-export-image';
+import {ExportMode, useExportImage} from '../../hooks/use-export-image';
 import {useHotkey} from '../../hooks/use-hotkey';
 import {AppLocaleEntries} from '../../i18n';
-import {DownloadIcon} from '../Icons/Download';
 import {ExternalLinkIcon} from '../Icons/ExternalLink';
-import {ExportDialog} from './ExportButton';
-import {ExportPopoverContent} from './ExportContent';
 
 interface ExportButtonProps {
   canvasRef: HTMLElement | undefined;
@@ -38,14 +25,14 @@ export const ExportInNewTabButton: Component<ExportButtonProps> = props => {
 
   function openInTab() {
     getUmami().trackEvent(`true`, 'export-new-tab');
-
+    const exportSettings = getExportCanvasStore();
     notify({
       ref: props.canvasRef,
       options: {
-        extension: ExportExtension.png,
+        extension: exportSettings.get.extension,
         mode: ExportMode.newTab,
-        quality: 100,
-        pixelRatio: Math.floor(window.devicePixelRatio),
+        quality: exportSettings.get.jpegQuality,
+        pixelRatio: Math.floor(exportSettings.get.devicePixelRatio),
       },
     });
   }
@@ -75,47 +62,14 @@ export const ExportInNewTabButton: Component<ExportButtonProps> = props => {
   });
 
   return (
-    <>
-      <div style={{display: 'flex'}}>
-        <Button
-          theme={'tertiary'}
-          leftIcon={<ExternalLinkIcon />}
-          loading={data.loading}
-          onClick={() => openInTab()}
-          size={props.size ?? (modality === 'full' ? 'sm' : 'xs')}
-          style={{
-            'border-bottom-right-radius': 0,
-            'border-top-right-radius': 0,
-          }}
-        >
-          {label()}
-        </Button>
-        <Popover placement={'bottom-end'}>
-          <PopoverTrigger asChild>
-            <As
-              component={IconButton}
-              aria-label={'hint'}
-              size={props.size ?? (modality === 'full' ? 'sm' : 'xs')}
-              theme={'tertiary'}
-              style={{
-                'border-bottom-left-radius': 0,
-                'border-top-left-radius': 0,
-                'border-left': '1px solid rgba(0,0,0,.20)',
-              }}
-            >
-              <SvgIcon
-                xmlns="http://www.w3.org/2000/svg"
-                viewBox="0 0 24 24"
-                fill="currentColor"
-                class="w-6 h-6"
-              >
-                <path d="M18.75 12.75h1.5a.75.75 0 000-1.5h-1.5a.75.75 0 000 1.5zM12 6a.75.75 0 01.75-.75h7.5a.75.75 0 010 1.5h-7.5A.75.75 0 0112 6zM12 18a.75.75 0 01.75-.75h7.5a.75.75 0 010 1.5h-7.5A.75.75 0 0112 18zM3.75 6.75h1.5a.75.75 0 100-1.5h-1.5a.75.75 0 000 1.5zM5.25 18.75h-1.5a.75.75 0 010-1.5h1.5a.75.75 0 010 1.5zM3 12a.75.75 0 01.75-.75h7.5a.75.75 0 010 1.5h-7.5A.75.75 0 013 12zM9 3.75a2.25 2.25 0 100 4.5 2.25 2.25 0 000-4.5zM12.75 12a2.25 2.25 0 114.5 0 2.25 2.25 0 01-4.5 0zM9 15.75a2.25 2.25 0 100 4.5 2.25 2.25 0 000-4.5z" />
-              </SvgIcon>
-            </As>
-          </PopoverTrigger>
-          <ExportPopoverContent onConfirm={() => void 0} />
-        </Popover>
-      </div>
-    </>
+    <Button
+      theme={'tertiary'}
+      leftIcon={<ExternalLinkIcon />}
+      loading={data.loading}
+      onClick={() => openInTab()}
+      size={props.size ?? (modality === 'full' ? 'sm' : 'xs')}
+    >
+      {label()}
+    </Button>
   );
 };

--- a/apps/codeimage/src/components/Toolbar/ExportSettingsButton.tsx
+++ b/apps/codeimage/src/components/Toolbar/ExportSettingsButton.tsx
@@ -1,0 +1,31 @@
+import {SvgIcon} from '@codeimage/ui';
+import {IconButton, Popover, PopoverTrigger, Tooltip} from '@codeui/kit';
+import {As} from '@kobalte/core';
+import {ExportPopoverContent} from './ExportContent';
+
+export function ExportSettingsButton() {
+  return (
+    <Tooltip content={'Export settings'} theme={'secondary'}>
+      <Popover placement={'bottom-end'}>
+        <PopoverTrigger asChild>
+          <As
+            component={IconButton}
+            aria-label={'hint'}
+            size={'xs'}
+            theme={'secondary'}
+          >
+            <SvgIcon
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 24 24"
+              fill="currentColor"
+              class="w-6 h-6"
+            >
+              <path d="M18.75 12.75h1.5a.75.75 0 000-1.5h-1.5a.75.75 0 000 1.5zM12 6a.75.75 0 01.75-.75h7.5a.75.75 0 010 1.5h-7.5A.75.75 0 0112 6zM12 18a.75.75 0 01.75-.75h7.5a.75.75 0 010 1.5h-7.5A.75.75 0 0112 18zM3.75 6.75h1.5a.75.75 0 100-1.5h-1.5a.75.75 0 000 1.5zM5.25 18.75h-1.5a.75.75 0 010-1.5h1.5a.75.75 0 010 1.5zM3 12a.75.75 0 01.75-.75h7.5a.75.75 0 010 1.5h-7.5A.75.75 0 013 12zM9 3.75a2.25 2.25 0 100 4.5 2.25 2.25 0 000-4.5zM12.75 12a2.25 2.25 0 114.5 0 2.25 2.25 0 01-4.5 0zM9 15.75a2.25 2.25 0 100 4.5 2.25 2.25 0 000-4.5z" />
+            </SvgIcon>
+          </As>
+        </PopoverTrigger>
+        <ExportPopoverContent onConfirm={() => void 0} />
+      </Popover>
+    </Tooltip>
+  );
+}

--- a/apps/codeimage/src/components/Toolbar/ExportSettingsButton.tsx
+++ b/apps/codeimage/src/components/Toolbar/ExportSettingsButton.tsx
@@ -24,7 +24,7 @@ export function ExportSettingsButton() {
             </SvgIcon>
           </As>
         </PopoverTrigger>
-        <ExportPopoverContent onConfirm={() => void 0} />
+        <ExportPopoverContent />
       </Popover>
     </Tooltip>
   );

--- a/apps/codeimage/src/components/Toolbar/FrameToolbar.tsx
+++ b/apps/codeimage/src/components/Toolbar/FrameToolbar.tsx
@@ -1,20 +1,13 @@
 import {getActiveEditorStore} from '@codeimage/store/editor/activeEditor';
 import {dispatchRandomTheme} from '@codeimage/store/effects/onThemeChange';
-import {HStack, SvgIcon} from '@codeimage/ui';
-import {
-  Button,
-  IconButton,
-  Popover,
-  PopoverTrigger,
-  Tooltip,
-} from '@codeui/kit';
+import {HStack} from '@codeimage/ui';
+import {Button} from '@codeui/kit';
 import {createAsyncAction} from '@core/hooks/async-action';
-import {As} from '@kobalte/core';
 import {ColorSwatchIcon} from '../Icons/ColorSwatch';
 import {SparklesIcon} from '../Icons/SparklesIcon';
 import {CopyToClipboardButton} from './CopyToClipboardButton';
-import {ExportPopoverContent} from './ExportContent';
 import {ExportInNewTabButton} from './ExportNewTabButton';
+import {ExportSettingsButton} from './ExportSettingsButton';
 import * as styles from './FrameToolbar.css';
 
 interface FrameToolbarProps {
@@ -30,28 +23,7 @@ export function FrameToolbar(props: FrameToolbarProps) {
   return (
     <div class={styles.frameToolbar}>
       <HStack spacing={2}>
-        <Tooltip content={'Export settings'} theme={'secondary'}>
-          <Popover placement={'bottom-end'}>
-            <PopoverTrigger asChild>
-              <As
-                component={IconButton}
-                aria-label={'hint'}
-                size={'xs'}
-                theme={'secondary'}
-              >
-                <SvgIcon
-                  xmlns="http://www.w3.org/2000/svg"
-                  viewBox="0 0 24 24"
-                  fill="currentColor"
-                  class="w-6 h-6"
-                >
-                  <path d="M18.75 12.75h1.5a.75.75 0 000-1.5h-1.5a.75.75 0 000 1.5zM12 6a.75.75 0 01.75-.75h7.5a.75.75 0 010 1.5h-7.5A.75.75 0 0112 6zM12 18a.75.75 0 01.75-.75h7.5a.75.75 0 010 1.5h-7.5A.75.75 0 0112 18zM3.75 6.75h1.5a.75.75 0 100-1.5h-1.5a.75.75 0 000 1.5zM5.25 18.75h-1.5a.75.75 0 010-1.5h1.5a.75.75 0 010 1.5zM3 12a.75.75 0 01.75-.75h7.5a.75.75 0 010 1.5h-7.5A.75.75 0 013 12zM9 3.75a2.25 2.25 0 100 4.5 2.25 2.25 0 000-4.5zM12.75 12a2.25 2.25 0 114.5 0 2.25 2.25 0 01-4.5 0zM9 15.75a2.25 2.25 0 100 4.5 2.25 2.25 0 000-4.5z" />
-                </SvgIcon>
-              </As>
-            </PopoverTrigger>
-            <ExportPopoverContent onConfirm={() => void 0} />
-          </Popover>
-        </Tooltip>
+        <ExportSettingsButton />
         <CopyToClipboardButton canvasRef={props.frameRef} />
         <Button
           size={'xs'}

--- a/apps/codeimage/src/components/Toolbar/FrameToolbar.tsx
+++ b/apps/codeimage/src/components/Toolbar/FrameToolbar.tsx
@@ -1,11 +1,19 @@
 import {getActiveEditorStore} from '@codeimage/store/editor/activeEditor';
 import {dispatchRandomTheme} from '@codeimage/store/effects/onThemeChange';
-import {HStack} from '@codeimage/ui';
-import {Button} from '@codeui/kit';
+import {HStack, SvgIcon} from '@codeimage/ui';
+import {
+  Button,
+  IconButton,
+  Popover,
+  PopoverTrigger,
+  Tooltip,
+} from '@codeui/kit';
 import {createAsyncAction} from '@core/hooks/async-action';
+import {As} from '@kobalte/core';
 import {ColorSwatchIcon} from '../Icons/ColorSwatch';
 import {SparklesIcon} from '../Icons/SparklesIcon';
 import {CopyToClipboardButton} from './CopyToClipboardButton';
+import {ExportPopoverContent} from './ExportContent';
 import {ExportInNewTabButton} from './ExportNewTabButton';
 import * as styles from './FrameToolbar.css';
 
@@ -22,6 +30,28 @@ export function FrameToolbar(props: FrameToolbarProps) {
   return (
     <div class={styles.frameToolbar}>
       <HStack spacing={2}>
+        <Tooltip content={'Export settings'} theme={'secondary'}>
+          <Popover placement={'bottom-end'}>
+            <PopoverTrigger asChild>
+              <As
+                component={IconButton}
+                aria-label={'hint'}
+                size={'xs'}
+                theme={'secondary'}
+              >
+                <SvgIcon
+                  xmlns="http://www.w3.org/2000/svg"
+                  viewBox="0 0 24 24"
+                  fill="currentColor"
+                  class="w-6 h-6"
+                >
+                  <path d="M18.75 12.75h1.5a.75.75 0 000-1.5h-1.5a.75.75 0 000 1.5zM12 6a.75.75 0 01.75-.75h7.5a.75.75 0 010 1.5h-7.5A.75.75 0 0112 6zM12 18a.75.75 0 01.75-.75h7.5a.75.75 0 010 1.5h-7.5A.75.75 0 0112 18zM3.75 6.75h1.5a.75.75 0 100-1.5h-1.5a.75.75 0 000 1.5zM5.25 18.75h-1.5a.75.75 0 010-1.5h1.5a.75.75 0 010 1.5zM3 12a.75.75 0 01.75-.75h7.5a.75.75 0 010 1.5h-7.5A.75.75 0 013 12zM9 3.75a2.25 2.25 0 100 4.5 2.25 2.25 0 000-4.5zM12.75 12a2.25 2.25 0 114.5 0 2.25 2.25 0 01-4.5 0zM9 15.75a2.25 2.25 0 100 4.5 2.25 2.25 0 000-4.5z" />
+                </SvgIcon>
+              </As>
+            </PopoverTrigger>
+            <ExportPopoverContent onConfirm={() => void 0} />
+          </Popover>
+        </Tooltip>
         <CopyToClipboardButton canvasRef={props.frameRef} />
         <Button
           size={'xs'}

--- a/apps/codeimage/src/hooks/use-export-image.ts
+++ b/apps/codeimage/src/hooks/use-export-image.ts
@@ -28,7 +28,6 @@ export const enum ExportExtension {
 export interface ExportOptions {
   extension: ExportExtension;
   mode: ExportMode;
-  fileName?: string;
   pixelRatio: number;
   quality: number;
 }
@@ -68,7 +67,7 @@ export async function exportImage(
   data: ExportImagePayload,
 ): Promise<Blob | string> {
   const {
-    options: {extension, fileName, mode, pixelRatio, quality},
+    options: {extension, mode, pixelRatio, quality},
     ref,
   } = data;
 
@@ -78,7 +77,7 @@ export async function exportImage(
     throw new Error('Reference is not defined.');
   }
 
-  const resolvedFileName = fileName || `codeImage_${new Date().getUTCDate()}`;
+  const resolvedFileName = `codeimage-snippet_${new Date().getUTCDate()}`;
   const mimeType = resolveMimeType(extension);
   const fileNameWithExtension = `${resolvedFileName}.${extension}`;
   const previewNode = ref.firstChild as HTMLElement;
@@ -206,9 +205,7 @@ export async function exportImage(
   const cb = exportByMode(previewNode);
 
   return cb
-    .then(r => {
-      return r as string | Blob;
-    })
+    .then(r => r as string | Blob)
     .catch(e => {
       throw e;
     });

--- a/apps/codeimage/src/hooks/use-export-image.ts
+++ b/apps/codeimage/src/hooks/use-export-image.ts
@@ -1,16 +1,14 @@
-import {
-  HtmlExportOptions,
-  toBlob,
-  toJpeg,
-  toPng,
-  toSvg,
-} from '@codeimage/dom-export';
+import {type HtmlExportOptions} from '@codeimage/dom-export';
 import {EXPORT_EXCLUDE} from '@core/directives/exportExclude';
 import {createAsyncAction} from '@core/hooks/async-action';
 import {useWebshare} from '@core/hooks/use-webshare';
 import {isIOS} from '@solid-primitives/platform';
 import download from 'downloadjs';
 import {Resource} from 'solid-js';
+
+function loadDomExport() {
+  return import('@codeimage/dom-export');
+}
 
 export const enum ExportMode {
   export = 'export',
@@ -105,6 +103,8 @@ export async function exportImage(
   };
 
   async function exportByMode(ref: HTMLElement) {
+    const {toBlob, toJpeg, toSvg, toPng} = await loadDomExport();
+
     switch (mode) {
       case 'share': {
         if (!supported()) {

--- a/apps/codeimage/src/hooks/use-export-image.ts
+++ b/apps/codeimage/src/hooks/use-export-image.ts
@@ -84,6 +84,7 @@ export async function exportImage(
   const previewNode = ref.firstChild as HTMLElement;
 
   const toImageOptions: HtmlExportOptions = {
+    type: mimeType,
     filter: (node: Node | undefined) => {
       const isNotExcluded = () => {
         const el = node as Element | null;

--- a/apps/codeimage/src/index.tsx
+++ b/apps/codeimage/src/index.tsx
@@ -13,15 +13,7 @@ import '@codeimage/ui/themes/lightTheme';
 import {Router, useRoutes} from '@solidjs/router';
 import {snackbarHostAppStyleCss} from '@ui/snackbarHostAppStyle.css';
 import {setElementVars} from '@vanilla-extract/dynamic';
-import {
-  Component,
-  createEffect,
-  lazy,
-  on,
-  Show,
-  Suspense,
-  untrack,
-} from 'solid-js';
+import {Component, createEffect, lazy, on, Show, Suspense} from 'solid-js';
 import {render} from 'solid-js/web';
 import {StateProvider} from 'statebuilder';
 import './assets/styles/app.scss';
@@ -136,7 +128,6 @@ export function Bootstrap() {
 
   return (
     <Scaffold>
-      <OverlayProvider />
       <CodeImageThemeProvider tokens={tokens} theme={mode()}>
         <SnackbarHost containerClassName={snackbarHostAppStyleCss} />
         <Router>

--- a/apps/codeimage/src/index.tsx
+++ b/apps/codeimage/src/index.tsx
@@ -13,7 +13,15 @@ import '@codeimage/ui/themes/lightTheme';
 import {Router, useRoutes} from '@solidjs/router';
 import {snackbarHostAppStyleCss} from '@ui/snackbarHostAppStyle.css';
 import {setElementVars} from '@vanilla-extract/dynamic';
-import {Component, createEffect, lazy, on, Show, Suspense} from 'solid-js';
+import {
+  Component,
+  createEffect,
+  lazy,
+  on,
+  Show,
+  Suspense,
+  untrack,
+} from 'solid-js';
 import {render} from 'solid-js/web';
 import {StateProvider} from 'statebuilder';
 import './assets/styles/app.scss';
@@ -128,6 +136,7 @@ export function Bootstrap() {
 
   return (
     <Scaffold>
+      <OverlayProvider />
       <CodeImageThemeProvider tokens={tokens} theme={mode()}>
         <SnackbarHost containerClassName={snackbarHostAppStyleCss} />
         <Router>

--- a/apps/codeimage/src/pages/Editor/App.tsx
+++ b/apps/codeimage/src/pages/Editor/App.tsx
@@ -21,6 +21,7 @@ import {Sidebar} from '../../components/Scaffold/Sidebar/Sidebar';
 import {ThemeSwitcher} from '../../components/ThemeSwitcher/ThemeSwitcher';
 import {ExportButton} from '../../components/Toolbar/ExportButton';
 import {ExportInNewTabButton} from '../../components/Toolbar/ExportNewTabButton';
+import {ExportSettingsButton} from '../../components/Toolbar/ExportSettingsButton';
 import {FrameToolbar} from '../../components/Toolbar/FrameToolbar';
 import {ShareButton} from '../../components/Toolbar/ShareButton';
 import {Toolbar} from '../../components/Toolbar/Toolbar';
@@ -85,6 +86,7 @@ export function App() {
             <Show when={modality === 'mobile'}>
               <Box class={styles.mobileActionToolbar}>
                 <HStack spacing={'2'} justifyContent={'flexEnd'}>
+                  <ExportSettingsButton />
                   <ShareButton showLabel={false} />
                   <Button
                     size={'xs'}

--- a/apps/codeimage/src/pages/Editor/App.tsx
+++ b/apps/codeimage/src/pages/Editor/App.tsx
@@ -1,3 +1,4 @@
+import {setCanvasSize} from '@codeimage/store/canvas';
 import {getActiveEditorStore} from '@codeimage/store/editor/activeEditor';
 import {getEditorSyncAdapter} from '@codeimage/store/editor/createEditorSync';
 import {getFrameState} from '@codeimage/store/editor/frame';
@@ -5,6 +6,7 @@ import {dispatchRandomTheme} from '@codeimage/store/effects/onThemeChange';
 import {adaptiveFullScreenHeight, Box, HStack, PortalHost} from '@codeimage/ui';
 import {Button} from '@codeui/kit';
 import {useModality} from '@core/hooks/isMobile';
+import {createResizeObserver} from '@solid-primitives/resize-observer';
 import {createSignal, lazy, Show, Suspense} from 'solid-js';
 import {BottomBar} from '../../components/BottomBar/BottomBar';
 import {Footer} from '../../components/Footer/Footer';
@@ -39,6 +41,13 @@ export function App() {
   const modality = useModality();
   const frameStore = getFrameState();
   const {readOnly, clone} = getEditorSyncAdapter()!;
+
+  createResizeObserver(frameRef, ref => {
+    setCanvasSize({
+      canvasHeight: ref.height,
+      canvasWidth: ref.width,
+    });
+  });
 
   return (
     <Box

--- a/apps/codeimage/src/pages/Editor/App.tsx
+++ b/apps/codeimage/src/pages/Editor/App.tsx
@@ -1,4 +1,4 @@
-import {setCanvasSize} from '@codeimage/store/canvas';
+import {getExportCanvasStore} from '@codeimage/store/canvas';
 import {getActiveEditorStore} from '@codeimage/store/editor/activeEditor';
 import {getEditorSyncAdapter} from '@codeimage/store/editor/createEditorSync';
 import {getFrameState} from '@codeimage/store/editor/frame';
@@ -6,8 +6,7 @@ import {dispatchRandomTheme} from '@codeimage/store/effects/onThemeChange';
 import {adaptiveFullScreenHeight, Box, HStack, PortalHost} from '@codeimage/ui';
 import {Button} from '@codeui/kit';
 import {useModality} from '@core/hooks/isMobile';
-import {createResizeObserver} from '@solid-primitives/resize-observer';
-import {createSignal, lazy, Show, Suspense} from 'solid-js';
+import {createSignal, lazy, onMount, Show, Suspense} from 'solid-js';
 import {BottomBar} from '../../components/BottomBar/BottomBar';
 import {Footer} from '../../components/Footer/Footer';
 import {FrameHandler} from '../../components/Frame/FrameHandler';
@@ -40,14 +39,9 @@ export function App() {
   const [portalHostRef, setPortalHostRef] = createSignal<HTMLElement>();
   const modality = useModality();
   const frameStore = getFrameState();
+  const exportCanvasStore = getExportCanvasStore();
   const {readOnly, clone} = getEditorSyncAdapter()!;
-
-  createResizeObserver(frameRef, ref => {
-    setCanvasSize({
-      canvasHeight: ref.height,
-      canvasWidth: ref.width,
-    });
-  });
+  onMount(() => exportCanvasStore.initCanvas(frameRef));
 
   return (
     <Box

--- a/apps/codeimage/src/state/canvas.ts
+++ b/apps/codeimage/src/state/canvas.ts
@@ -1,6 +1,68 @@
-import {createStore} from 'solid-js/store';
+import {provideAppState} from '@codeimage/store/index';
+import {withIndexedDbPlugin} from '@codeimage/store/plugins/withIndexedDbPlugin';
+import {createResizeObserver} from '@solid-primitives/resize-observer';
+import {Accessor, createEffect, on} from 'solid-js';
+import {defineStore} from 'statebuilder';
+import {ExportExtension} from '../hooks/use-export-image';
 
-export const [canvasSize, setCanvasSize] = createStore({
-  canvasWidth: 0,
-  canvasHeight: 0,
-});
+export interface PersistedExportCanvasSettings {
+  devicePixelRatio: number;
+  jpegQuality: number;
+  extension: ExportExtension;
+}
+
+export const ExportCanvasStore = defineStore(() => ({
+  canvasSize: {
+    width: 0,
+    height: 0,
+  },
+  devicePixelRatio: 3,
+  jpegQuality: 100,
+  extension: ExportExtension.png,
+}))
+  .extend(
+    withIndexedDbPlugin<PersistedExportCanvasSettings>('exportSettings', {
+      devicePixelRatio: 3,
+      jpegQuality: 100,
+      extension: ExportExtension.png,
+    }),
+  )
+  .extend((store, context) => {
+    createEffect(
+      on(store, value => {
+        store.idb.set({
+          devicePixelRatio: value.devicePixelRatio,
+          jpegQuality: value.jpegQuality,
+          extension: value.extension,
+        });
+      }),
+    );
+    context.hooks.onInit(() => {
+      store.idb.get().then(value =>
+        store.set(prevValue => ({
+          ...prevValue,
+          ...value,
+        })),
+      );
+    });
+  })
+  .extend(store => ({
+    canvasResolution() {
+      const canvasSize = store.get.canvasSize;
+      const height = Math.ceil(canvasSize.height) * store.get.devicePixelRatio;
+      const width = Math.ceil(canvasSize.width) * store.get.devicePixelRatio;
+      return `${width}x${height}`;
+    },
+    setCanvasSize(width: number, height: number) {
+      store.set('canvasSize', {width, height});
+    },
+    initCanvas(el: Accessor<HTMLElement | undefined>) {
+      createResizeObserver(el, ref =>
+        this.setCanvasSize(ref.width, ref.height),
+      );
+    },
+  }));
+
+export function getExportCanvasStore() {
+  return provideAppState(ExportCanvasStore);
+}

--- a/apps/codeimage/src/state/canvas.ts
+++ b/apps/codeimage/src/state/canvas.ts
@@ -1,0 +1,6 @@
+import {createStore} from 'solid-js/store';
+
+export const [canvasSize, setCanvasSize] = createStore({
+  canvasWidth: 0,
+  canvasHeight: 0,
+});

--- a/apps/codeimage/src/state/effects/onCopyToClipboard.tsx
+++ b/apps/codeimage/src/state/effects/onCopyToClipboard.tsx
@@ -1,12 +1,12 @@
 import {effect} from '@codeimage/atomic-state';
 import {useI18n} from '@codeimage/locale';
+import {getExportCanvasStore} from '@codeimage/store/canvas';
 import {getUiStore} from '@codeimage/store/ui';
 import {toast} from '@codeimage/ui';
 import {getUmami} from '@core/constants/umami';
 import {catchError, EMPTY, exhaustMap, from, pipe, switchMap, tap} from 'rxjs';
 import {getOwner, runWithOwner} from 'solid-js';
 import {
-  ExportExtension,
   exportImage,
   ExportMode,
   ExportOptions,
@@ -22,11 +22,12 @@ const owner = getOwner()!;
 export const dispatchCopyToClipboard = effect<CopyToClipboardEvent>(
   pipe(
     exhaustMap(({ref}) => {
+      const exportSettings = getExportCanvasStore();
       const options: ExportOptions = {
         mode: ExportMode.getBlob,
-        quality: 100,
-        pixelRatio: Math.floor(window.devicePixelRatio),
-        extension: ExportExtension.png,
+        quality: exportSettings.get.jpegQuality,
+        pixelRatio: Math.floor(exportSettings.get.devicePixelRatio),
+        extension: exportSettings.get.extension,
       };
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       return from(runWithOwner(owner, () => exportImage({ref, options}))!).pipe(

--- a/packages/dom-export/src/lib/index.ts
+++ b/packages/dom-export/src/lib/index.ts
@@ -128,7 +128,7 @@ export async function toBlob<T extends HTMLElement>(
   options: Options = {},
 ): Promise<Blob | null> {
   const canvas = await toCanvas(node, options);
-  const blob = await canvasToBlob(canvas);
+  const blob = await canvasToBlob(canvas, options);
   return blob;
 }
 


### PR DESCRIPTION
#509 


- [X] ~~Add @codeui/kit Add customizable popover width (e.g. AutoWidth property) or custom class forwarding~~ Added "DynamicSizedContainer" on app core
- [X] ~~Move segmented field to @codeui/kit to follow right color tokens~~ Will be done later
- [X] ~~Add ButtonGroup or generic Group support to @codeui/kit (maybe follow approach of https://taiga-ui.dev/components/group#buttons)~~ Not needed anymore