### PR TITLE
fix: disable box-shadow rendering on ios/safari

### DIFF
--- a/.changeset/chilly-elephants-retire.md
+++ b/.changeset/chilly-elephants-retire.md
@@ -1,0 +1,5 @@
+---
+"@codeimage/dom-export": patch
+---
+
+fix: disable box-shadow rendering on ios/safari

--- a/packages/dom-export/src/lib/cloneNode.ts
+++ b/packages/dom-export/src/lib/cloneNode.ts
@@ -1,4 +1,4 @@
-import {isIOS} from '@solid-primitives/platform';
+import {isIOS, isSafari} from '@solid-primitives/platform';
 import {clonePseudoElements} from './clonePseudoElements';
 import {copyFont, copyUserComputedStyleFast} from './cloneStyle';
 import {getBlobFromURL} from './getBlobFromURL';
@@ -119,7 +119,7 @@ function cloneCSSStyle<T extends HTMLElement>(
   }
 
   const boxShadow = sourceStyle.getPropertyValue('boxShadow');
-  if (boxShadow !== 'none' && isIOS) {
+  if (boxShadow !== 'none' && (isIOS || isSafari)) {
     clonedNode.setAttribute(
       'style',
       `${clonedNode.getAttribute('style')};box-shadow:none!important;`,

--- a/packages/dom-export/src/lib/clonePseudoElements.ts
+++ b/packages/dom-export/src/lib/clonePseudoElements.ts
@@ -1,3 +1,4 @@
+import {isIOS, isSafari} from '@solid-primitives/platform';
 import {toArray, uuid} from './util';
 
 type Pseudo = ':before' | ':after';
@@ -24,6 +25,9 @@ function getPseudoElementStyle(
   style: CSSStyleDeclaration,
 ): Text {
   const selector = `.${className}:${pseudo}`;
+  if (isIOS || isSafari) {
+    style.boxShadow = 'unset';
+  }
   const cssText = style.cssText
     ? formatCSSText(style)
     : formatCSSProperties(style);


### PR DESCRIPTION
Safari has a lot of issues rendering box-shadow. There is not an official fix for this one so I'm disabling it all shadows while exporting an image in ios/macos safari